### PR TITLE
Fix issues with connection base api

### DIFF
--- a/src/components/SettingsPage/api/axios.js
+++ b/src/components/SettingsPage/api/axios.js
@@ -1,5 +1,6 @@
 import globalAxios from 'axios';
+const BASE_URL = require("../../../assets/FetchServices/BaseUrl.json").value;
 
 export const axios = globalAxios.create({
-  baseURL: 'http://localhost:3000/api/', // Base URL for all requests
+  baseURL: `${BASE_URL}/api/`, // Base URL for all requests
 });


### PR DESCRIPTION
Settings Page will get base url based on general file of the main application:

export const axios = globalAxios.create({
  baseURL: `${BASE_URL}/api/`, // Base URL for all requests
});

- Minor change
- Ready to merge