### PR TITLE
Set Sidebar size to 14px (0.875rem)

### DIFF
--- a/src/components/PeopleComponents/SideBar.js
+++ b/src/components/PeopleComponents/SideBar.js
@@ -20,7 +20,7 @@ function CustomListItem(props) {
     <ListItem>
       <ListItemButton>
         {icon ? <ListItemIcon>{icon}</ListItemIcon> : null}
-        <ListItemText primary={primary} />
+        <ListItemText primary={primary} sx={{ "& .MuiTypography-root": { fontSize: "0.875rem" } }} />
       </ListItemButton>
     </ListItem>
   );


### PR DESCRIPTION
Fixes #111

Updated sidebar font size from 16px to 14px (via 0.875rem) for all rows, including menu items and the support link, as per the Figma design.

Verified that the current BlueWave HRM logo matches the latest version in Figma and does not need to be updated — the visible background is already transparent.